### PR TITLE
Fix SVG rendering in TS4.4 fix

### DIFF
--- a/src/nodes.ts
+++ b/src/nodes.ts
@@ -40,12 +40,11 @@ function getNamespaceForTag(tag: string, parent: Node | null) {
     return null;
   }
   
-  if (parent instanceof Element) {
-    // namespaceURI is only defined for Attr and Element nodes
-    // but we only consider Element nodes as parents.
-    return parent.namespaceURI;
-  }
-  return null;
+  // Since TypeScript 4.4 namespaceURI is only defined for Attr and
+  // Element nodes. Checking for Element nodes here seems reasonable
+  // but brakes SVG rendering in Chrome in certain cases. The cast to
+  // any should be removed once we know why this happens.
+  return (parent as any).namespaceURI;
 }
 
 /**


### PR DESCRIPTION
The change to make the code compatible with TypeScript 4.4 broke SVG rendering in certain cases in Chrome.

This should hopefully be a temporary fix until we figure out what the reason for the SVG breakage is.